### PR TITLE
Clockserver

### DIFF
--- a/src/pioneer-p3dx/p3dx_hal_vrep/launch/hal_vrep.launch
+++ b/src/pioneer-p3dx/p3dx_hal_vrep/launch/hal_vrep.launch
@@ -7,7 +7,6 @@
     <include file="$(find p3dx_urdf_model)/launch/pioneer3dx_urdf.launch" />
 
     <!-- hal members -->
-    <node pkg="p3dx_hal_vrep" type="clockServer" name="clockServer" respawn="true" />
     <node pkg="p3dx_hal_vrep" type="laser" name="laser" respawn="true" />
     <node pkg="p3dx_hal_vrep" type="accelerometer" name="accelerometer" respawn="true" />
     <node pkg="p3dx_hal_vrep" type="gyroscope" name="gyro" respawn="true" />

--- a/src/pioneer-p3dx/p3dx_hal_vrep/src/clockServer.cpp
+++ b/src/pioneer-p3dx/p3dx_hal_vrep/src/clockServer.cpp
@@ -4,20 +4,31 @@
 
 #include <string>
 
-const int SIM_STARTED = 1;
+constexpr unsigned int SIM_STARTED_MASK = 1;
 ros::Publisher clock_publisher;
 ros::Subscriber vrep_clock_subscriber;
 
 float sim_time = -1;
 
-void updateClock(const vrep_common::VrepInfo::ConstPtr & new_time) {
-  if (SIM_STARTED == new_time->simulatorState.data) {
-    sim_time = new_time->simulationTime.data;
-    rosgraph_msgs::Clock c;
-    c.clock.sec = static_cast<uint32_t>(sim_time);
-    c.clock.nsec = static_cast<uint32_t>((sim_time - c.clock.sec) * 1000000000);
-    clock_publisher.publish(c);
+void updateClock(const vrep_common::VrepInfo::ConstPtr& new_time) {
+  /*
+    simulatorState.data is bitwise encoded state
+    bit0 set: simulation not stopped
+    bit1 set: simulation paused
+    bit2 set: real-time switch on
+    bit3-bit5: the edit mode type (0=no edit mode, 1=triangle, 2=vertex, 3=edge, 4=path, 5=UI)
+  */
+  if (!(new_time->simulatorState.data & SIM_STARTED_MASK)) {
+    return;
   }
+
+  sim_time = new_time->simulationTime.data;
+  rosgraph_msgs::Clock c;
+  /* convert float time to sec a nano sec */
+  c.clock.sec = static_cast<uint32_t>(sim_time);
+  c.clock.nsec = static_cast<uint32_t>((sim_time - c.clock.sec) * 1000000000);
+
+  clock_publisher.publish(c);
 }
 
 int main(int argc, char **argv) {

--- a/src/pioneer-p3dx/p3dx_robot/launch/clock.launch
+++ b/src/pioneer-p3dx/p3dx_robot/launch/clock.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="p3dx_hal_vrep" type="clockServer" name="vrep_clock_server" respawn="true" />
+</launch>


### PR DESCRIPTION
vrep clock server: everything was wrong …
Simulator state was handled incorrectly. Mask was used as signed integer, mask compared to data etc. All was doomed to fail.

Added comments explainig the whole situation to prevent such embarrasing situations in the future.

remove clockserver from hal …
Clock server was moved to its own launchfile. Prevents launching multiple clockservers in multirobot setup.
