### PR TITLE
Localization prefix

### DIFF
--- a/src/pioneer-p3dx/p3dx_dpl/launch/dpl.launch
+++ b/src/pioneer-p3dx/p3dx_dpl/launch/dpl.launch
@@ -1,13 +1,10 @@
 <!-- launch all dpl nodes -->
 <launch>
-  <!-- this file expects `tf_prefix` arg to be declared -->
-  <arg name="tf_prefix" />
   <group ns="dpl">
     <!-- hal is foreign dpl member -->
     <include file="$(find p3dx_hal_vrep)/launch/hal_vrep.launch" />
-    <include file="$(find p3dx_dpl)/launch/robot_localization_ekf.launch">
-      <arg name="tf_prefix" value="$(arg tf_prefix)" />
-    </include>
+    <include file="$(find p3dx_dpl)/launch/robot_localization_ekf.launch" />
+
     <!-- dpl members -->
     <node pkg="p3dx_dpl" type="motor_controler" name="motor_ctl" respawn="true" />
     <node pkg="p3dx_dpl" type="imu_provider" name="imu_provider" respawn="true" />

--- a/src/pioneer-p3dx/p3dx_dpl/launch/robot_localization_ekf.launch
+++ b/src/pioneer-p3dx/p3dx_dpl/launch/robot_localization_ekf.launch
@@ -1,8 +1,6 @@
 <!-- Launch file for ekf_localization_node -->
 
 <launch>
-    <!-- this file expects `tf_prefix` arg to be declared -->
-    <arg name="tf_prefix" />
     <!-- This node will take in measurements from odometry, IMU, stamped pose, and stamped twist messages. It tracks
          the state of the robot, with the state vector being defined as X position, Y position, Z position,
          roll, pitch, yaw, their respective velocites, and linear acceleration. Units for all measurements are assumed

--- a/src/pioneer-p3dx/p3dx_dpl/launch/robot_localization_ekf.launch
+++ b/src/pioneer-p3dx/p3dx_dpl/launch/robot_localization_ekf.launch
@@ -54,7 +54,7 @@
       <!-- Defaults to "base_link" if unspecified -->
       <param name="base_link_frame" value="base_footprint"/>
       <!-- Defaults to the value of "odom_frame" if unspecified -->
-      <param name="world_frame" value="$(arg tf_prefix)/odom"/>
+      <param name="world_frame" value="odom"/>
 
       <!-- The filter accepts an arbitrary number of inputs from each input message type (Odometry, PoseStamped,
            TwistStamped, Imu). To add a new one, simply append the next number in the sequence to its base name,

--- a/src/pioneer-p3dx/p3dx_robot/launch/p3dx.launch
+++ b/src/pioneer-p3dx/p3dx_robot/launch/p3dx.launch
@@ -8,9 +8,7 @@
     <param name="vrep_index" type="int" value="$(arg vrep_id)" />
 
     <!-- run dpl -->
-    <include file="$(find p3dx_dpl)/launch/dpl.launch">
-      <arg name="tf_prefix" value="$(arg tf_prefix)" />
-    </include>
+    <include file="$(find p3dx_dpl)/launch/dpl.launch" />
 
     <!-- nodes in robot -->
     <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">


### PR DESCRIPTION
remove prefix from ekf_localization odom …
ekf_localization resolves tf_prefix by itself. Current setup resolves in duplicate prefix.

remove tf_prefix propagation as argument …
it is no longer necessary to propagate tf_prefix as argument to launchfiles. Launchfiles are now standalone without providing any params.
