### PR TITLE
fix hal_vrep dependencies

### DIFF
--- a/src/pioneer-p3dx/p3dx_hal_vrep/CMakeLists.txt
+++ b/src/pioneer-p3dx/p3dx_hal_vrep/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(bumper src/bumper.cpp)
 target_link_libraries(bumper ${catkin_LIBRARIES})
 
 add_executable(clockServer src/clockServer.cpp)
+add_dependencies(clockServer vrep_common_generate_messages_cpp)
 target_link_libraries(clockServer ${catkin_LIBRARIES})
 
 #############


### PR DESCRIPTION
clockServer needs vrep_common message. Therefore it needs to declare dependency on vrep_common messages explicitly.

This was really broken. Anyone adding new depencies in the future must make sure that the project build clean! It means cleaning ros workspace and build workspace from scratch!
